### PR TITLE
[terminal] restore local scripts and add appuser variants

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -32,4 +32,12 @@ Checks for the presence of key files, directories, binaries, and shell config ch
 ./verify_local_terminal_env.sh
 ```
 
+## reset_appuser_terminal_env.sh
+Performs the same cleanup as `reset_local_terminal_env.sh` but targets the
+`appuser` account. Useful when the playbook was executed as that user.
+
+## verify_appuser_terminal_env.sh
+Runs the verification checks against the `appuser` environment instead of the
+current user.
+
 *For development use only. These scripts are destructive and not intended for production systems.*

--- a/scripts/reset_appuser_terminal_env.sh
+++ b/scripts/reset_appuser_terminal_env.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Reset the terminal environment for the dedicated appuser account. This mirrors
+# reset_local_terminal_env.sh but operates on the appuser home directory.
+
+TARGET_USER="appuser"
+HOME_DIR="$(eval echo ~${TARGET_USER})"
+
+# Remove core directories and completions
+rm -rf "$HOME_DIR/.local/bin"
+rm -rf "$HOME_DIR/.config/shell_init.d"
+rm -rf "$HOME_DIR/.bash_completion.d"
+rm -rf "$HOME_DIR/.zsh/completions"
+rm -rf "$HOME_DIR/.config/fish/completions"
+
+# Remove tool-specific directories
+rm -rf "$HOME_DIR/.nvm"
+# WARNING: Deleting ~/.pyenv will break all Python virtual environments created with Pyenv.
+# Uncomment the next line ONLY if you want to fully remove all Pyenv-managed Pythons for appuser.
+# rm -rf "$HOME_DIR/.pyenv"
+rm -rf "$HOME_DIR/.cargo"
+rm -rf "$HOME_DIR/.sheldon"
+rm -rf "$HOME_DIR/.fzf"
+rm -rf "$HOME_DIR/.config/starship.toml"
+rm -rf "$HOME_DIR/.config/starship"
+rm -rf "$HOME_DIR/.config/bat"
+rm -rf "$HOME_DIR/.config/eza"
+rm -rf "$HOME_DIR/.config/zoxide"
+rm -rf "$HOME_DIR/.config/direnv"
+rm -rf "$HOME_DIR/.config/uv"
+
+# Remove shell init snippets for tools
+rm -f "$HOME_DIR/.config/shell_init.d/10-nvm.sh"
+rm -f "$HOME_DIR/.config/shell_init.d/10-pyenv.sh"
+rm -f "$HOME_DIR/.config/shell_init.d/10-rustup.sh"
+
+# Remove lines sourcing shell_init.d from shell configs
+sed -i.bak '/shell_init\.d/d' "$HOME_DIR/.bashrc" 2>/dev/null || true
+sed -i.bak '/shell_init\.d/d' "$HOME_DIR/.zshrc" 2>/dev/null || true
+sed -i.bak '/shell_init\.d/d' "$HOME_DIR/.profile" 2>/dev/null || true
+
+# Remove the artifact cache (hard-coded path)
+rm -rf /tmp/terminal-ansible-artifacts
+
+# Optionally remove backup files created by sed
+rm -f "$HOME_DIR/.bashrc.bak" "$HOME_DIR/.zshrc.bak" "$HOME_DIR/.profile.bak"
+
+echo "[reset_appuser_terminal_env.sh] Reset complete for ${TARGET_USER}. Please restart the shell."

--- a/scripts/reset_local_terminal_env.sh
+++ b/scripts/reset_local_terminal_env.sh
@@ -32,15 +32,15 @@ rm -f ~/.config/shell_init.d/10-nvm.sh
 rm -f ~/.config/shell_init.d/10-pyenv.sh
 rm -f ~/.config/shell_init.d/10-rustup.sh
 
-# FIX: Completely delete the shell configuration files for a true reset.
-for shellrc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
-  echo "[reset] Deleting $shellrc if it exists..."
-  rm -f "$shellrc"
-  # Also remove any stray backups from previous sed runs
-  rm -f "${shellrc}.bak"
-done
+# Remove lines sourcing shell_init.d from shell configs
+sed -i.bak '/shell_init\.d/d' ~/.bashrc 2>/dev/null || true
+sed -i.bak '/shell_init\.d/d' ~/.zshrc 2>/dev/null || true
+sed -i.bak '/shell_init\.d/d' ~/.profile 2>/dev/null || true
 
 # Remove the artifact cache (hard-coded path)
 rm -rf /tmp/terminal-ansible-artifacts
+
+# Optionally remove backup files created by sed
+rm -f ~/.bashrc.bak ~/.zshrc.bak ~/.profile.bak
 
 echo "[reset_local_terminal_env.sh] Reset complete. Please restart your shell."

--- a/scripts/verify_appuser_terminal_env.sh
+++ b/scripts/verify_appuser_terminal_env.sh
@@ -1,8 +1,12 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# This script verifies that the eddiedunn.terminal local setup playbook has completed its intended operations.
-# It checks for key directories, files, binaries, and shell config changes.
+# Verify the terminal setup for the dedicated appuser account. This mirrors
+# verify_local_terminal_env.sh but targets the appuser home directory.
+
+TARGET_USER="appuser"
+HOME_DIR="$(eval echo ~${TARGET_USER})"
+USER_CMD=(sudo -Hiu "${TARGET_USER}" --)
 
 failures=0
 
@@ -25,9 +29,9 @@ check_dir() {
 }
 
 check_bin() {
-  if command -v "$1" >/dev/null 2>&1; then
+  if "${USER_CMD[@]}" command -v "$1" >/dev/null 2>&1; then
     echo "[OK] On PATH: $1"
-  elif [ -x "$HOME/.local/bin/$1" ]; then
+  elif [ -x "$HOME_DIR/.local/bin/$1" ]; then
     echo "[OK] $1 found in ~/.local/bin (not on PATH)"
   else
     echo "[FAIL] Not found: $1 (not on PATH or in ~/.local/bin)"
@@ -36,21 +40,21 @@ check_bin() {
 }
 
 # Check core directories
-check_dir "$HOME/.local/bin"
-check_dir "$HOME/.config/shell_init.d"
-check_dir "$HOME/.bash_completion.d"
-check_dir "$HOME/.zsh/completions"
-check_dir "$HOME/.config/fish/completions"
+check_dir "$HOME_DIR/.local/bin"
+check_dir "$HOME_DIR/.config/shell_init.d"
+check_dir "$HOME_DIR/.bash_completion.d"
+check_dir "$HOME_DIR/.zsh/completions"
+check_dir "$HOME_DIR/.config/fish/completions"
 
 # Check tool-specific directories for version managers
-for d in "$HOME/.nvm" "$HOME/.pyenv" "$HOME/.cargo"; do
+for d in "$HOME_DIR/.nvm" "$HOME_DIR/.pyenv" "$HOME_DIR/.cargo"; do
   check_dir "$d"
 done
 
 # Check important shell init snippets
-for f in "$HOME/.config/shell_init.d/10-nvm.sh" \
-         "$HOME/.config/shell_init.d/10-pyenv.sh" \
-         "$HOME/.config/shell_init.d/10-rustup.sh"; do
+for f in "$HOME_DIR/.config/shell_init.d/10-nvm.sh" \
+         "$HOME_DIR/.config/shell_init.d/10-pyenv.sh" \
+         "$HOME_DIR/.config/shell_init.d/10-rustup.sh"; do
   check_exists "$f"
 done
 
@@ -68,7 +72,7 @@ else
 fi
 
 # Check for shell sourcing
-for shellrc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
+for shellrc in "$HOME_DIR/.bashrc" "$HOME_DIR/.zshrc" "$HOME_DIR/.profile"; do
   if grep -q 'shell_init.d' "$shellrc" 2>/dev/null; then
     echo "[OK] $shellrc sources shell_init.d"
   else
@@ -78,9 +82,9 @@ for shellrc in "$HOME/.bashrc" "$HOME/.zshrc" "$HOME/.profile"; do
 done
 
 if [ "$failures" -eq 0 ]; then
-  echo "[verify_local_terminal_env.sh] All checks passed."
+  echo "[verify_appuser_terminal_env.sh] All checks passed."
   exit 0
 else
-  echo "[verify_local_terminal_env.sh] $failures check(s) failed."
+  echo "[verify_appuser_terminal_env.sh] $failures check(s) failed."
   exit 1
 fi


### PR DESCRIPTION
## Summary
- restore `verify_local_terminal_env.sh` and `reset_local_terminal_env.sh` to their previous logic
- add `verify_appuser_terminal_env.sh` and `reset_appuser_terminal_env.sh` for checking and resetting the `appuser` account
- document the new scripts in `scripts/README.md`

## Testing
- `ansible-playbook tests/test.yml` *(fails: playbook not found)*
- `ansible-test units` *(fails: current working directory must be within the source tree)*
- `ansible-test sanity` *(fails: current working directory must be within the source tree)*
- `ansible-test integration` *(fails: current working directory must be within the source tree)*
- `ansible-lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686ddfd5207c8330a453b0b74ef1f789