### PR TITLE
[terminal] Add local setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,6 +3,17 @@
 ## Development Environment Setup
 None. Everything will already be set up for you. There is a user named app user. The idea is that we will run `playbooks/local_setup.yml` using sudo as the user `appuser` we will then check the playbook output as well as the user's home directory to ensure everything is set up correctly.
 
+After verifying your environment, build and install the collection so the playbook has access to required roles and modules. Run:
+```
+ansible-galaxy collection build . --force
+ansible-galaxy collection install ./eddiedunn-terminal-1.0.0.tar.gz --force -p /usr/share/ansible/collections
+```
+Next, execute the setup playbook as the `appuser` and verify the environment:
+```
+sudo -u appuser ansible-playbook playbooks/local_setup.yml
+./scripts/verify_appuser_terminal_env.sh
+```
+If the environment has no internet access, expect failures when the playbook tries to download external binaries.
 
 
 ## Testing Guidelines
@@ -28,5 +39,4 @@ None. Everything will already be set up for you. There is a user named app user.
 - Reference related issues in the PR description using `Fixes #123` or `Related to #123`
 - Include test cases for new features or bug fixes
 - Update documentation to reflect any changes
-- Ensure your code passes all CI/CD pipeline checks
-- Keep PRs focused on a single feature or bug fix
+- Ensure your code passes all CI/CD pipeline checks- Keep PRs focused on a single feature or bug fix


### PR DESCRIPTION
## Summary
- document how to build and install the collection
- outline running the local setup playbook as appuser
- mention lack of internet access failures

## Testing
- `ansible-playbook tests/test.yml` *(fails: playbook not found)*
- `ansible-test units -v` *(fails: No "ansible_collections" parent directory)*
- `ansible-test sanity` *(fails: No "ansible_collections" parent directory)*
- `ansible-lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686de2dca7088330aac451838b120ae5