### PR TITLE
[terminal] Add linux binary support and run playbook

### DIFF
--- a/roles/nvm/tasks/main.yml
+++ b/roles/nvm/tasks/main.yml
@@ -11,6 +11,7 @@
     dest: "{{ ansible_user_dir }}/.nvm"
     version: "{{ nvm_version }}"
     force: false
+    recursive: false
 
 - name: "Deploy NVM init script"
   ansible.builtin.template:

--- a/roles/tool_installer/defaults/main.yml
+++ b/roles/tool_installer/defaults/main.yml
@@ -38,6 +38,10 @@ tool_installer_all_definitions:
         aarch64:
           url: "https://github.com/starship/starship/releases/download/v1.23.0/starship-aarch64-apple-darwin.tar.gz"
           executable_in_archive: "starship"
+      Linux:
+        x86_64:
+          url: "https://github.com/starship/starship/releases/download/v1.23.0/starship-x86_64-unknown-linux-musl.tar.gz"
+          executable_in_archive: "starship"
     dependencies: {}
 
   - name: ripgrep
@@ -69,6 +73,10 @@ tool_installer_all_definitions:
         aarch64:
           url: "https://github.com/rossmacarthur/sheldon/releases/download/0.8.2/sheldon-0.8.2-aarch64-apple-darwin.tar.gz"
           executable_in_archive: "sheldon"
+      Linux:
+        x86_64:
+          url: "https://github.com/rossmacarthur/sheldon/releases/download/0.8.2/sheldon-0.8.2-x86_64-unknown-linux-musl.tar.gz"
+          executable_in_archive: "sheldon"
     dependencies: {}
 
   - name: fzf
@@ -94,6 +102,9 @@ tool_installer_all_definitions:
         aarch64:
           url: "https://github.com/junegunn/fzf/releases/download/v0.62.0/fzf-0.62.0-linux_arm64.tar.gz"
           executable_in_archive: "fzf"
+        x86_64:
+          url: "https://github.com/junegunn/fzf/releases/download/v0.62.0/fzf-0.62.0-linux_amd64.tar.gz"
+          executable_in_archive: "fzf"
     dependencies: {}
 
   - name: bat
@@ -104,6 +115,10 @@ tool_installer_all_definitions:
         aarch64:
           url: "https://github.com/sharkdp/bat/releases/download/v0.25.0/bat-v0.25.0-aarch64-apple-darwin.tar.gz"
           executable_in_archive: "bat"
+      Linux:
+        x86_64:
+          url: "https://github.com/sharkdp/bat/releases/download/v0.25.0/bat-v0.25.0-x86_64-unknown-linux-musl.tar.gz"
+          executable_in_archive: "bat"
     dependencies: {}
 
   - name: eza
@@ -113,6 +128,10 @@ tool_installer_all_definitions:
       Darwin:
         aarch64:
           url: "https://github.com/eddiedunn/eza/releases/download/v0.21.4-darwin/eza"
+          executable_in_archive: "eza"
+      Linux:
+        x86_64:
+          url: "https://github.com/eza-community/eza/releases/download/v0.21.4/eza_x86_64-unknown-linux-gnu.tar.gz"
           executable_in_archive: "eza"
     dependencies: {}
 
@@ -127,6 +146,10 @@ tool_installer_all_definitions:
         aarch64:
           url: "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.8/zoxide-0.9.8-aarch64-apple-darwin.tar.gz"
           executable_in_archive: "zoxide"
+      Linux:
+        x86_64:
+          url: "https://github.com/ajeetdsouza/zoxide/releases/download/v0.9.8/zoxide-0.9.8-x86_64-unknown-linux-musl.tar.gz"
+          executable_in_archive: "zoxide"
     dependencies: {}
 
   - name: direnv
@@ -139,6 +162,10 @@ tool_installer_all_definitions:
         aarch64:
           url: "https://github.com/direnv/direnv/releases/download/v2.33.0/direnv.darwin-arm64"
           executable_in_archive: "direnv"
+      Linux:
+        x86_64:
+          url: "https://github.com/direnv/direnv/releases/download/v2.33.0/direnv.linux-amd64"
+          executable_in_archive: "direnv"
     dependencies: {}
 
   - name: uv
@@ -148,6 +175,10 @@ tool_installer_all_definitions:
       Darwin:
         aarch64:
           url: "https://github.com/astral-sh/uv/releases/download/0.7.13/uv-aarch64-apple-darwin.tar.gz"
+          executable_in_archive: "uv"
+      Linux:
+        x86_64:
+          url: "https://github.com/astral-sh/uv/releases/download/0.7.13/uv-x86_64-unknown-linux-gnu.tar.gz"
           executable_in_archive: "uv"
     dependencies: {}
 

--- a/roles/tool_installer/tasks/download_binaries.yml
+++ b/roles/tool_installer/tasks/download_binaries.yml
@@ -7,6 +7,7 @@
     path: "{{ role_path }}/scripts"
     state: directory
     mode: '0755'
+  become: true
   delegate_to: localhost
   run_once: true
 - name: Execute binary download and verification script
@@ -14,6 +15,7 @@
     cmd: "python3 {{ role_path }}/scripts/download_helper.py {{ role_path }}"
   register: script_result
   changed_when: "'CHANGED' in script_result.stdout"
+  become: true
   delegate_to: localhost
   run_once: true
   args:


### PR DESCRIPTION
## Summary
- add `recursive: false` to nvm clone so playbook works without submodules
- add linux x86_64 download URLs for various tools
- run download helper with `become` since the collection installs into root owned directories

## Testing
- `ansible-galaxy collection build . --force`
- `ansible-galaxy collection install ./eddiedunn-terminal-1.0.0.tar.gz --force -p /usr/share/ansible/collections`
- `sudo -u appuser ansible-playbook playbooks/local_setup.yml`
- `./scripts/verify_appuser_terminal_env.sh`
- `ansible-lint` *(fails: 13 failure(s))*
- `ansible-test units` *(fails: no tests found)*
- `ansible-test sanity` *(fails: python3.13 command not found)*


------
https://chatgpt.com/codex/tasks/task_b_686de569b8188330b92ed10ce0c408cb