### PR TITLE
[terminal] Expand verification scripts

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -7,7 +7,7 @@ Removes all files, directories, binaries, and configuration changes created by t
 
 - Removes:
   - `~/.local/bin`, `~/.config/shell_init.d`, completions directories
-  - Tool-specific directories (e.g., `~/.nvm`, `~/.pyenv`, `~/.cargo`, etc.)
+  - Tool-specific directories (e.g., `~/.nvm`, `~/.pyenv`, `~/.cargo`, `~/.sdkman`, Go directories)
   - Shell init snippets for tools
   - Sourcing lines from `.bashrc`, `.zshrc`, `.profile`
   - The artifact cache at `/tmp/terminal-ansible-artifacts`
@@ -16,10 +16,11 @@ Removes all files, directories, binaries, and configuration changes created by t
 Checks for the presence of key files, directories, binaries, and shell config changes expected after running the local setup playbook. Use this to confirm the playbook worked as intended.
 
 - Checks:
-  - Core and tool-specific directories
-  - Shell init snippets
+  - Core and tool-specific directories, including SDKMAN and Go
+  - Shell init snippets for all tools
   - Binaries on PATH
   - Artifact cache presence
+  - Configuration files like `starship.toml` and `sheldon/plugins.toml`
   - Sourcing of shell_init.d in shell configs
 
 ---

--- a/scripts/verify_appuser_terminal_env.sh
+++ b/scripts/verify_appuser_terminal_env.sh
@@ -46,21 +46,40 @@ check_dir "$HOME_DIR/.bash_completion.d"
 check_dir "$HOME_DIR/.zsh/completions"
 check_dir "$HOME_DIR/.config/fish/completions"
 
-# Check tool-specific directories for version managers
-for d in "$HOME_DIR/.nvm" "$HOME_DIR/.pyenv" "$HOME_DIR/.cargo"; do
+# Check tool-specific directories for version managers and language runtimes
+for d in \
+  "$HOME_DIR/.nvm" \
+  "$HOME_DIR/.pyenv" \
+  "$HOME_DIR/.cargo" \
+  "$HOME_DIR/.sdkman" \
+  "$HOME_DIR/.local/go" \
+  "$HOME_DIR/go" \
+  "$HOME_DIR/go/bin"; do
   check_dir "$d"
 done
 
 # Check important shell init snippets
-for f in "$HOME_DIR/.config/shell_init.d/10-nvm.sh" \
-         "$HOME_DIR/.config/shell_init.d/10-pyenv.sh" \
-         "$HOME_DIR/.config/shell_init.d/10-rustup.sh"; do
+for f in \
+  "$HOME_DIR/.config/shell_init.d/00_path.sh" \
+  "$HOME_DIR/.config/shell_init.d/10_environment.sh" \
+  "$HOME_DIR/.config/shell_init.d/10-nvm.sh" \
+  "$HOME_DIR/.config/shell_init.d/10-pyenv.sh" \
+  "$HOME_DIR/.config/shell_init.d/10-rustup.sh" \
+  "$HOME_DIR/.config/shell_init.d/10-sdkman.sh" \
+  "$HOME_DIR/.config/shell_init.d/20_go.sh"; do
   check_exists "$f"
 done
 
 # Check for all installed binaries
-for bin in starship sheldon fzf bat eza ripgrep zoxide direnv uv; do
+for bin in starship sheldon fzf bat eza ripgrep zoxide direnv uv go; do
   check_bin "$bin"
+done
+
+# Check additional configuration files
+for f in \
+  "$HOME_DIR/.config/starship.toml" \
+  "$HOME_DIR/.config/sheldon/plugins.toml"; do
+  check_exists "$f"
 done
 
 # Check artifact cache

--- a/scripts/verify_local_terminal_env.sh
+++ b/scripts/verify_local_terminal_env.sh
@@ -42,21 +42,40 @@ check_dir "$HOME/.bash_completion.d"
 check_dir "$HOME/.zsh/completions"
 check_dir "$HOME/.config/fish/completions"
 
-# Check tool-specific directories for version managers
-for d in "$HOME/.nvm" "$HOME/.pyenv" "$HOME/.cargo"; do
+# Check tool-specific directories for version managers and language runtimes
+for d in \
+  "$HOME/.nvm" \
+  "$HOME/.pyenv" \
+  "$HOME/.cargo" \
+  "$HOME/.sdkman" \
+  "$HOME/.local/go" \
+  "$HOME/go" \
+  "$HOME/go/bin"; do
   check_dir "$d"
 done
 
 # Check important shell init snippets
-for f in "$HOME/.config/shell_init.d/10-nvm.sh" \
-         "$HOME/.config/shell_init.d/10-pyenv.sh" \
-         "$HOME/.config/shell_init.d/10-rustup.sh"; do
+for f in \
+  "$HOME/.config/shell_init.d/00_path.sh" \
+  "$HOME/.config/shell_init.d/10_environment.sh" \
+  "$HOME/.config/shell_init.d/10-nvm.sh" \
+  "$HOME/.config/shell_init.d/10-pyenv.sh" \
+  "$HOME/.config/shell_init.d/10-rustup.sh" \
+  "$HOME/.config/shell_init.d/10-sdkman.sh" \
+  "$HOME/.config/shell_init.d/20_go.sh"; do
   check_exists "$f"
 done
 
 # Check for all installed binaries
-for bin in starship sheldon fzf bat eza ripgrep zoxide direnv uv; do
+for bin in starship sheldon fzf bat eza ripgrep zoxide direnv uv go; do
   check_bin "$bin"
+done
+
+# Check additional configuration files
+for f in \
+  "$HOME/.config/starship.toml" \
+  "$HOME/.config/sheldon/plugins.toml"; do
+  check_exists "$f"
 done
 
 # Check artifact cache


### PR DESCRIPTION
## Summary
- check SDKMAN and Go directories in verify scripts
- verify init snippets and config files for all tools
- document expanded checks in script README

## Testing
- `ansible-galaxy collection build . --force`
- `ansible-galaxy collection install ./eddiedunn-terminal-1.0.0.tar.gz --force -p /usr/share/ansible/collections`
- `sudo -u appuser ansible-playbook playbooks/local_setup.yml`
- `./scripts/verify_appuser_terminal_env.sh`

------
https://chatgpt.com/codex/tasks/task_b_686dea03665483309c5aabdb7ee19da3