### PR TITLE
[terminal] make local playbook path configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,7 +294,7 @@ Replace `<your_namespace>` with the actual namespace (e.g., `eddiedunn`).
 
 ## Reference: Source Role
 - Role name: `terminal_setup`
-- Path: `/Users/tmwsiy/code/gaia-infra-platform/ansible/roles/terminal_setup`
+- Path: `<path_to_repo>/ansible/roles/terminal_setup`
 
 ---
 

--- a/ansible-playbook-local
+++ b/ansible-playbook-local
@@ -44,7 +44,10 @@ echo "[ansible-playbook-local] Installing Ansible collection from: $TARBALL"
 ansible-galaxy collection install "$TARBALL" --force
 
 # Step 2: Run ansible-playbook with the correct environment
-export ANSIBLE_COLLECTIONS_PATHS=/Users/tmwsiy/code
+# If LOCAL_COLLECTIONS_PATH is set, use it to override ANSIBLE_COLLECTIONS_PATHS
+if [ -n "$LOCAL_COLLECTIONS_PATH" ]; then
+  export ANSIBLE_COLLECTIONS_PATHS="$LOCAL_COLLECTIONS_PATH"
+fi
 
 # Run ansible-playbook with the correct environment
 exec ansible-playbook "$@"


### PR DESCRIPTION
## Summary
- allow `ansible-playbook-local` to use a custom `ANSIBLE_COLLECTIONS_PATHS`
- generalize hard-coded user path in README

## Testing
- `ansible-lint` *(fails: command not found)*
- `ansible-playbook tests/test.yml` *(fails: playbook not found)*
- `ansible-test units` *(fails: working directory not within collection)*
- `ansible-test sanity` *(fails: working directory not within collection)*
- `ansible-test integration` *(fails: working directory not within collection)*

------
https://chatgpt.com/codex/tasks/task_b_686deebaab7483308eb66a31400b9709