### PR TITLE
[terminal] Consolidate sheldon config setup

### DIFF
--- a/roles/tool_installer/tasks/manage_sheldon_config.yml
+++ b/roles/tool_installer/tasks/manage_sheldon_config.yml
@@ -12,17 +12,6 @@
     state: directory
     mode: '0755'
 
-- name: "Set Sheldon-specific paths"
-  ansible.builtin.set_fact:
-    sheldon_config_dir: "{{ ansible_user_dir }}/.config/sheldon"
-    sheldon_config_file: "{{ ansible_user_dir }}/.config/sheldon/plugins.toml"
-
-- name: "Sheldon | Ensure config directory exists"
-  ansible.builtin.file:
-    path: "{{ sheldon_config_dir }}"
-    state: directory
-    mode: '0755'
-
 - name: "Sheldon | Deploy plugins.toml configuration"
   ansible.builtin.template:
     src: sheldon/plugins.toml.j2


### PR DESCRIPTION
## Summary
- de-dupe sheldon set_fact and directory creation

## Testing
- `ansible-galaxy collection build . --force`
- `ansible-galaxy collection install ./eddiedunn-terminal-1.0.0.tar.gz --force -p /usr/share/ansible/collections`
- `sudo -u appuser ansible-playbook playbooks/local_setup.yml` *(fails: execution interrupted)*
- `./scripts/verify_appuser_terminal_env.sh`
- `ansible-playbook tests/test.yml` *(fails: playbook not found)*
- `ansible-test units` *(fails: must run inside ansible_collections)*
- `ansible-test sanity` *(fails: must run inside ansible_collections)*
- `ansible-test integration` *(fails: must run inside ansible_collections)*
- `ansible-lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686deeb2c23c8330a13a68c0c4108f9c