### PR TITLE
[terminal] make Docker socket and collections path configurable

### DIFF
--- a/ansible-playbook-local
+++ b/ansible-playbook-local
@@ -1,6 +1,10 @@
 #!/bin/sh
 set -e
 
+# Environment variables:
+#   ANSIBLE_COLLECTIONS_PATHS - Optional path where the collection will be installed
+#     and searched. If unset, the Ansible defaults are used.
+
 COLLECTION_DIR="$(dirname "$0")"
 # Parse namespace and name from galaxy.yml
 NAMESPACE=$(awk -F': ' '/^namespace:/ {print $2}' "$COLLECTION_DIR/galaxy.yml" | tr -d '"')
@@ -41,13 +45,11 @@ else
 fi
 
 echo "[ansible-playbook-local] Installing Ansible collection from: $TARBALL"
-ansible-galaxy collection install "$TARBALL" --force
-
-# Step 2: Run ansible-playbook with the correct environment
-# If LOCAL_COLLECTIONS_PATH is set, use it to override ANSIBLE_COLLECTIONS_PATHS
-if [ -n "$LOCAL_COLLECTIONS_PATH" ]; then
-  export ANSIBLE_COLLECTIONS_PATHS="$LOCAL_COLLECTIONS_PATH"
+if [ -n "${ANSIBLE_COLLECTIONS_PATHS:-}" ]; then
+  ansible-galaxy collection install "$TARBALL" --force -p "$ANSIBLE_COLLECTIONS_PATHS"
+else
+  ansible-galaxy collection install "$TARBALL" --force
 fi
 
-# Run ansible-playbook with the correct environment
+# Step 2: Run ansible-playbook with the correct environment
 exec ansible-playbook "$@"

--- a/scripts/molecule_all.sh
+++ b/scripts/molecule_all.sh
@@ -1,8 +1,13 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Always use Colima docker socket for tmwsiy
-export DOCKER_HOST=unix:///Users/tmwsiy/.colima/docker.sock
+# Environment variables:
+#   COLIMA_SOCKET - Optional path to a custom Docker socket. If set, DOCKER_HOST
+#     will be configured to use this socket.
+
+if [ -n "${COLIMA_SOCKET:-}" ]; then
+  export DOCKER_HOST="unix://$COLIMA_SOCKET"
+fi
 
 # Activate the Python venv for ansible/molecule
 source "$(dirname "$0")/../../.venv/bin/activate"


### PR DESCRIPTION
## Summary
- use `ANSIBLE_COLLECTIONS_PATHS` for installing the collection in `ansible-playbook-local`
- make DOCKER_HOST optional in `scripts/molecule_all.sh`
- document the environment variables at the top of each script

## Testing
- `ansible-lint`
- `ansible-playbook tests/test.yml` *(fails: playbook not found)*
- `ansible-test units` *(fails: no `ansible_collections` parent directory)*
- `ansible-test sanity` *(fails: no `ansible_collections` parent directory)*
- `ansible-test integration` *(fails: no `ansible_collections` parent directory)*

------
https://chatgpt.com/codex/tasks/task_b_686df0376a188330ba21dd09eb39817a