### PR TITLE
[terminal] Add collection overview

### DIFF
--- a/docs/COLLECTION_README.md
+++ b/docs/COLLECTION_README.md
@@ -1,1 +1,27 @@
-# Placeholder for collection-level README. See role READMEs for details.
+# eddiedunn.terminal Collection Overview
+
+This collection assembles several roles to configure a reproducible terminal environment on Linux and macOS. The `profile` role is the main entry point and pulls in helper roles such as `tool_installer`, `system_dependencies`, `nvm`, `pyenv`, and `rustup` to install tools and set up shell integrations.
+
+## Installation
+
+Build and install from the collection root:
+
+```bash
+ansible-galaxy collection build --force
+ansible-galaxy collection install ./eddiedunn-terminal-*.tar.gz --force -p ~/.ansible/collections
+```
+
+Alternatively, add `eddiedunn.terminal` to your `collections/requirements.yml` and run `ansible-galaxy collection install -r collections/requirements.yml`.
+
+## Usage
+
+Reference roles using their fully qualified collection name. Example:
+
+```yaml
+- hosts: all
+  roles:
+    - eddiedunn.terminal.profile
+```
+
+Role-specific documentation with variables and examples lives in each role's `README.md` under `roles/<role_name>/`. See `docs/BINARY_MANAGEMENT.md` and `docs/COMPLETIONS_WORKFLOW.md` for more details on binaries and completions.
+


### PR DESCRIPTION
## Summary
- document collection-level usage

## Testing
- `ansible-galaxy collection build . --force`
- `ansible-galaxy collection install ./eddiedunn-terminal-1.0.0.tar.gz --force -p /usr/share/ansible/collections`
- `sudo -u appuser ansible-playbook playbooks/local_setup.yml`
- `./scripts/verify_appuser_terminal_env.sh`
- `ansible-playbook tests/test.yml` *(fails: playbook not found)*
- `ansible-test units --color --verbose` *(fails: no tests)*
- `ansible-test sanity --color --verbose` *(fails: command returned exit status 127)*
- `ansible-test integration --color --verbose` *(fails: no integration tests)*
- `ansible-lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_686df037341883308a81deaab547bab6